### PR TITLE
Getting REVISION from config instead of file

### DIFF
--- a/post-deploy
+++ b/post-deploy
@@ -16,7 +16,7 @@ if [[ $API_KEY ]]; then
   REPO_URL=$(dokku config:get "$APP" AIRBRAKE_REPO_URL || echo "dokku@$(cat "$DOKKU_ROOT/VHOST"):$APP")
   BASE_URL=$(dokku config:get "$APP" AIRBRAKE_BASE_URL || echo 'https://airbrake.io')
   RAILS_ENV=$(dokku config:get "$APP" RACK_ENV || dokku config:get "$APP" RAILS_ENV || echo 'production')
-  GIT_REV=$(cat "$APP_ROOT/.dokku-git-rev" 2> /dev/null || printf '0%.0s' {1..41})
+  GIT_REV=$(dokku config:get "$APP" GIT_REV || printf '0%.0s' {1..41})
   GIT_MESSAGE=$(git log "$GIT_REV" -n1 --pretty='format:%s' 2> /dev/null || echo '')
   dokku_log_info1 "Notifying airbrake..."
   curl "$BASE_URL/deploys.txt" --silent \


### PR DESCRIPTION
`.dokku-git-rev` is no longer available, but `GIT_REV` environment variable is.
This PR changes the source of the value and fixes sending only zeroes to Airbrake.